### PR TITLE
Making sure query string parameters are encoded

### DIFF
--- a/src/SilkierQuartz/Views/Jobs/Index.hbs
+++ b/src/SilkierQuartz/Views/Jobs/Index.hbs
@@ -139,8 +139,8 @@
     function bindContextMenu(menu, row, jobName, jobGroup) {
 
         menu.find('>.menu-edit').attr('href', row.find('>.job-name a').attr('href'));
-        menu.find('>.menu-copy').attr('href', '{{ActionUrl "Duplicate"}}?group=' + jobGroup + '&name=' + jobName);
-        menu.find('>.menu-trigger').attr('href', '{{ActionUrl "Trigger"}}?group=' + jobGroup + '&name=' + jobName);
+        menu.find('>.menu-copy').attr('href', '{{ActionUrl "Duplicate"}}?group=' + encodeURIComponent(jobGroup) + '&name=' + encodeURIComponent(jobName));
+        menu.find('>.menu-trigger').attr('href', '{{ActionUrl "Trigger"}}?group=' + encodeURIComponent(jobGroup) + '&name=' + encodeURIComponent(jobName));
         menu.find('>.menu-delete').click(function () {
             $('#delete-dialog .confirm-item').text(jobGroup +'.' + jobName);
             deleteItem({ name: jobName, group: jobGroup }, $('#msg-panel'),

--- a/src/SilkierQuartz/Views/Triggers/Index.hbs
+++ b/src/SilkierQuartz/Views/Triggers/Index.hbs
@@ -206,7 +206,7 @@
         mnuResume.click(pauseResumeFunc);
 
         menu.find('>.menu-edit').attr('href', row.find('>.trigger-name a').attr('href'));
-        menu.find('>.menu-copy').attr('href', '{{ActionUrl "Duplicate"}}?group=' + triggerGroup + '&name=' + triggerName);
+        menu.find('>.menu-copy').attr('href', '{{ActionUrl "Duplicate"}}?group=' + encodeURIComponent(triggerGroup) + '&name=' + encodeURIComponent(triggerName));
         menu.find('>.menu-delete').click(function () {
             $('#delete-dialog .confirm-item').text(triggerGroup + '.' + triggerName);
             deleteItem({ name: triggerName, group: triggerGroup }, $('#msg-panel'),


### PR DESCRIPTION
This PR fixes the following error:

1.) Create a Job with a name containing a special character (I used `M&S`)
2.) Save it and return to `Jobs` Index view.
3.) For the newly created job, clock on the dots and select `Copy` from the menu.
![image](https://github.com/user-attachments/assets/31a9fca3-c8ad-4b87-9cb1-595dde6c16d2)
4.) The application errors out with 500 error.

This is because the Job's name is passed using query string which leads to unexpected behaviour if not handled carefully.
In this case the query string ended up being: 

```
?group=DEFAULT&name=M&S
```

Which looks like `S` was another parameter without value. Instead, the correct way to pass `M&S` is:

```
?group=DEFAULT&name=M%26S
```

The same problem applies to triggers' names, which I also fixed in this PR.
