### PR TITLE
Including user's login in the trigger's name

### DIFF
--- a/src/SilkierQuartz/Controllers/AuthenticateController.cs
+++ b/src/SilkierQuartz/Controllers/AuthenticateController.cs
@@ -96,11 +96,7 @@ namespace SilkierQuartz.Controllers
             {
                 new Claim(ClaimTypes.NameIdentifier, string.IsNullOrEmpty(userName)
                     ? "SilkierQuartzAdmin"
-                    : authenticationOptions.UserName),
-
-                new Claim(ClaimTypes.Name, string.IsNullOrEmpty(password)
-                    ? "SilkierQuartzPassword"
-                    : authenticationOptions.Password),
+                    : userName),
 
                 new Claim(authenticationOptions.SilkierQuartzClaim, authenticationOptions.SilkierQuartzClaimValue)
             };


### PR DESCRIPTION
After allowing multiple users by providing custom authentication mechanism, I found it difficult to find out who triggered jobs. I think that it is possible to easily include this information in the trigger's name. E.g.

![image](https://github.com/user-attachments/assets/c7efb8a1-e917-41f1-9b83-0de7d2a6180b)
(In the session presented in the screen above, I'm logged in as "MyUser123")

I've come up with a suggestion for a naming convention for such triggers, but I don't insist on it.