### PR TITLE
Exposing Cookie name as a parameter.

### DIFF
--- a/src/SilkierQuartz/Authorization/SilkierQuartzAuthenticationOptions.cs
+++ b/src/SilkierQuartz/Authorization/SilkierQuartzAuthenticationOptions.cs
@@ -57,5 +57,11 @@ namespace SilkierQuartz
         /// Set to true to skip all requirement checks in <see cref="SilkierQuartzDefaultAuthorizationHandler"/>
         /// </summary>
         public bool SkipDefaultRequirementHandler { get; set; } = false;
+
+        /// <summary>
+        /// Provide a name for CookieAuthenticationOptions.Cookie.Name field used to configure services.AddCookie.
+        /// The value is only used when <see cref="SimpleAccessRequirement"/> is NOT set to <see cref="SimpleAccessRequirement.AllowAnonymous"/>
+        /// </summary>
+        public string CookieName { get; set; } = "sq_authenticationOptions.AuthScheme";
     }
 }

--- a/src/SilkierQuartz/Configuration/ServiceCollectionExtensions.cs
+++ b/src/SilkierQuartz/Configuration/ServiceCollectionExtensions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     .AddAuthentication(authenticationOptions.AuthScheme)
                     .AddCookie(authenticationOptions.AuthScheme, cfg =>
                     {
-                        cfg.Cookie.Name = $"sq_authenticationOptions.AuthScheme";
+                        cfg.Cookie.Name = authenticationOptions.CookieName;
                         cfg.Cookie.Path = options.VirtualPathRoot;
                         cfg.LoginPath = $"{options.VirtualPathRoot}{(options.VirtualPathRoot.EndsWith('/') ? "" : "/")}Authenticate/Login";
                         cfg.AccessDeniedPath = $"{options.VirtualPathRoot}{(options.VirtualPathRoot.EndsWith('/') ? "" : "/")}Authenticate/Login";


### PR DESCRIPTION
In my case I have multiple instances of SilkierQuartz and I reliazed switching between them causes some problems due to the fact they both use the same Cookie name.

In this PR I exposed this as a parameter of `SilkierQuartzAuthenticationOptions`, with default value set to the currently used `"sq_authenticationOptions.AuthScheme"`.

Is this something interesting from your perspective?